### PR TITLE
BouncyCastle.Cryptography nuget fix

### DIFF
--- a/TuviSRPLib/Sample/Sample.csproj
+++ b/TuviSRPLib/Sample/Sample.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -19,15 +19,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\TuviSRPLib\TuviSRPLib.csproj" />
-  </ItemGroup>
-
-  <!-- In current version of BouncyCastle.Cryptography there is a problem with finding interfaces implementations. 
-  So as temporarily solution we use next insertion taken from https://github.com/bcgit/bc-csharp/issues/447 -->
-  <ItemGroup>
-    <PackageReference Include="BouncyCastle.Cryptography" Version="2.2.1" ExcludeAssets="Compile" GeneratePathProperty="true" />
-    <Reference Include="BouncyCastle.Cryptography">
-      <HintPath>$(PkgBouncyCastle_Cryptography)\lib\netstandard2.0\BouncyCastle.Cryptography.dll</HintPath>
-    </Reference>
   </ItemGroup>
 
 </Project>

--- a/TuviSRPLib/TuviSRPLib/ExtendedHashDigest.cs
+++ b/TuviSRPLib/TuviSRPLib/ExtendedHashDigest.cs
@@ -52,6 +52,15 @@ namespace TuviSRPLib
             _message = newMessage;
         }
 
+#if NETCOREAPP2_1_OR_GREATER || !NETSTANDARD2_1_OR_GREATER
+        /// <summary>Update the message digest with a span of bytes.</summary>
+        /// <param name="input">the span containing the data.</param>
+        public void BlockUpdate(ReadOnlySpan<byte> input)
+        {
+             throw new NotImplementedException();
+        }
+#endif
+
         /// <summary>
         /// Close the digest, producing the final digest value. The doFinal call leaves the digest reset.
         /// </summary>
@@ -77,6 +86,17 @@ namespace TuviSRPLib
 
             return DigestLength;
         }
+
+#if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>Close the digest, producing the final digest value.</summary>
+        /// <remarks>This call leaves the digest reset.</remarks>
+        /// <param name="output">the span the digest is to be copied into.</param>
+        /// <returns>the number of bytes written</returns>
+        public int DoFinal(Span<byte> output)
+        {
+            throw new NotImplementedException();
+        }
+#endif
 
         public int GetByteLength()
         {

--- a/TuviSRPLib/TuviSRPLib/ExtendedHashDigest.cs
+++ b/TuviSRPLib/TuviSRPLib/ExtendedHashDigest.cs
@@ -52,7 +52,7 @@ namespace TuviSRPLib
             _message = newMessage;
         }
 
-#if NETCOREAPP2_1_OR_GREATER || !NETSTANDARD2_1_OR_GREATER
+#if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
         /// <summary>Update the message digest with a span of bytes.</summary>
         /// <param name="input">the span containing the data.</param>
         public void BlockUpdate(ReadOnlySpan<byte> input)

--- a/TuviSRPLib/TuviSRPLib/TuviSRPLib.csproj
+++ b/TuviSRPLib/TuviSRPLib/TuviSRPLib.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/TuviSRPLib/TuviSRPLibTests/TuviSRPLibTests.csproj
+++ b/TuviSRPLib/TuviSRPLibTests/TuviSRPLibTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -23,15 +23,6 @@
     <PackageReference Include="NUnit.Analyzers" Version="3.7.0" />
   </ItemGroup>
 
-  <!-- In current version of BouncyCastle.Cryptography there is a problem with finding interfaces implementations. 
-  So as temporarily solution we use next insertion taken from https://github.com/bcgit/bc-csharp/issues/447 -->
-  <ItemGroup>
-    <PackageReference Include="BouncyCastle.Cryptography" Version="2.2.1" ExcludeAssets="Compile" GeneratePathProperty="true" />
-    <Reference Include="BouncyCastle.Cryptography">
-      <HintPath>$(PkgBouncyCastle_Cryptography)\lib\netstandard2.0\BouncyCastle.Cryptography.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-  
   <ItemGroup>
     <ProjectReference Include="..\ProtonBase64Lib\ProtonBase64Lib.csproj" />
     <ProjectReference Include="..\TuviSRPLib\TuviSRPLib.csproj" />


### PR DESCRIPTION
add net6.0 TrargetFramework
update ExtendedHashDigest class
remove `BouncyCastle.Cryptography` nuget hack fix

Opened #23 issue for implementing methods: **BlockUpdate** and **DoFinal**.
